### PR TITLE
feat: improve error handling and user feedback in build scripts

### DIFF
--- a/oe_container_build_quickstart.sh
+++ b/oe_container_build_quickstart.sh
@@ -69,7 +69,7 @@ get_user_choice() {
                 return
             fi
         done
-        echo -e "${RED}Invalid choice. Please try again.${NC}"
+        echo -e "${RED}Invalid choice. Please try again.${NC}" >&2
     done
 }
 
@@ -537,8 +537,11 @@ run_interactive() {
                 
                 if [[ $? -ne 0 ]]; then
                     # User chose to quit
+                    echo -e "${YELLOW}Component selection cancelled${NC}"
                     continue
                 fi
+                
+                echo -e "${GREEN}Selected components: $comp${NC}"
                 
                 invoke_build_images "$comp" "$VERSION" "$DOCKER_USERNAME" "false"
                 

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -179,9 +179,12 @@ if [[ -z "$OEVERSION" ]]; then
 fi
 
 JDK_KEY="jdk${OEVERSION}"
-JDK_VERSION_VALUE=$(jq -r ".${JDK_KEY}" "$JDK_JSON")
-if [[ -z "$JDK_VERSION_VALUE" || "$JDK_VERSION_VALUE" == "null" ]]; then
+# Parse JSON without jq dependency - extract value for the key
+JDK_VERSION_VALUE=$(awk -F'"' "/\"${JDK_KEY}\":/ {print \$4}" "$JDK_JSON")
+if [[ -z "$JDK_VERSION_VALUE" ]]; then
   echo "Error: No JDK mapping found for key '$JDK_KEY' in $JDK_JSON" >&2
+  echo "Available keys in $JDK_JSON:" >&2
+  grep -o '"jdk[^"]*"' "$JDK_JSON" | sed 's/"//g' >&2
   exit 1
 fi
 


### PR DESCRIPTION
- Redirected error message to stderr in get_user_choice() for proper error stream handling
- Added informative messages for component selection status in interactive mode
- Replaced jq dependency with awk for JDK version parsing in build-image.sh
- Enhanced error output to show available JDK versions when mapping fails
- Improved error handling for invalid JDK version scenarios