### PR TITLE
style: remove trailing colon from version prompt

### DIFF
--- a/oe_container_build_quickstart.ps1
+++ b/oe_container_build_quickstart.ps1
@@ -456,7 +456,7 @@ function Invoke-Main {
             # Get version if not provided
             if ([string]::IsNullOrEmpty($Version)) {
                 Write-Host ""
-                $Version = Read-Host 'Enter OpenEdge version (e.g., 12.8.9): '
+                $Version = Read-Host 'Enter OpenEdge version (e.g., 12.8.9)'
             }
             
             switch ($choice) {


### PR DESCRIPTION
- Removed unnecessary trailing colon from the OpenEdge version input prompt for cleaner user interaction
- Maintains consistent prompt style with other system dialogs