### PR TITLE
fix: restrict OpenEdge file cleanup to PAS_DEV containers only

### DIFF
--- a/scripts/clean-oe-files.sh
+++ b/scripts/clean-oe-files.sh
@@ -3,7 +3,7 @@
 CONTAINERTYPE=$1
 
 case "$CONTAINERTYPE" in
-    PAS*)
+    PAS_DEV)
         rm -rf /usr/dlc/*OpenEdge*
         rm -rf /usr/dlc/*sports*
         rm -f /usr/dlc/bin/*sql*


### PR DESCRIPTION
- Changed cleanup script condition from PAS* wildcard to specific PAS_DEV match
- Prevents unintended file removal from PAS_PROD and other PAS container types