### PR TITLE
feat: add PAS Oracle DataServer container and enhance CDC initialization

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             matrix:
                 version: [ 12.8.11 ] # make sure all response.ini files are available as secrets
-                containertype: [ "PAS_BASE" ] # ["PAS_DEV", "PAS_PROD", "DB_ADV", "COMPILER"]
+                containertype: [ "DB_ADV" ] # ["PAS_DEV", "PAS_PROD", "DB_ADV", "COMPILER"]
 
         steps:
 

--- a/db_adv/scripts/startdb.sh
+++ b/db_adv/scripts/startdb.sh
@@ -181,6 +181,13 @@ sleep 2
 # Initialize CDC if CDC_TABLES is set
 if [[ -n "${CDC_TABLES}" ]]; then
     echo "CDC_TABLES environment variable found: ${CDC_TABLES}"
+    echo "Enabling CDC for the database"
+    ${DLC}/bin/proutil /app/db/${DBNAME} -C enablecdc area "Change Data Area" indexarea "Change Index Area"
+    if [ $? -eq 0 ]; then
+        echo "[INFO] CDC enabled for ${DBNAME}"
+    else
+        echo "[ERROR] Failed to enable CDC for ${DBNAME}"
+    fi
     echo "Initializing CDC for specified tables..."
     
     # CDC_TABLES format: "table1:level1,table2:level2" or just "table1,table2" (defaults to level 3)
@@ -200,9 +207,9 @@ if [[ -n "${CDC_TABLES}" ]]; then
         /app/scripts/init-cdc.sh ${DBNAME} ${table_name} ${cdc_level}
         
         if [ $? -eq 0 ]; then
-            echo "  ✓ CDC enabled for ${table_name}"
+            echo "[INFO] CDC enabled for ${table_name}"
         else
-            echo "  ✗ Failed to enable CDC for ${table_name}"
+            echo "[ERROR] Failed to enable CDC for ${table_name}"
         fi
     done
     

--- a/pas_orads/Dockerfile
+++ b/pas_orads/Dockerfile
@@ -1,7 +1,36 @@
-# Oracle client stage
-FROM ubuntu:22.04 AS oracle
+# Stage 1: Install OpenEdge
+FROM ubuntu:22.04 AS install
 
-USER 0
+ARG CTYPE
+ARG OEVERSION
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:JDKVERSION $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Add OpenEdge installer files
+ADD installer/PROGRESS_OE.tar.gz /install/openedge/
+ADD installer/PROGRESS_PATCH_OE.tar.gz /install/patch/
+ADD scripts/install-oe.sh /install/
+
+# Create required directories for version 12.2
+RUN if [ "${OEVERSION}" = "122" ] ; then mkdir /etc/progress; else echo "false" ; fi && \
+    if [ "${OEVERSION}" = "122" ] ; then mkdir /etc/openedge; else echo "false" ; fi && \
+    if [ "${OEVERSION}" = "122" ] ; then touch /etc/openedge.d; else echo "false" ; fi 
+
+COPY pas_orads/response*.ini /install/openedge/
+ENV TERM=xterm
+
+# Install OpenEdge and clean up unnecessary files
+COPY scripts/clean-oe-files.sh /install/openedge/clean-oe-files.sh 
+RUN /install/install-oe.sh && \
+    cat /install/install_oe.log && \
+    rm /usr/dlc/progress.cfg && \
+    /install/openedge/clean-oe-files.sh ${CTYPE} && \
+    rm -rf /install
+
+# Stage 2: Install Oracle client
+FROM ubuntu:22.04 AS oracle
 
 RUN mkdir /install/ && \
     mkdir -p /opt/oracle && \
@@ -25,35 +54,73 @@ RUN rm -rf libexpat.so.1 && \
     ln -s libexpat.so.1.6.8 libexpat.so.1 && \
     ldconfig /opt/oracle/client/lib
 
-# Build on top of pas_base and add Oracle client
-FROM progressofficial/oe_pas_base:12.8.11
+# Stage 3: Final runtime image
+FROM ubuntu:22.04 AS runtime
 
 LABEL maintainer="Ruben Dröge <rdroge@progress.com>"
 
-USER root
-
-# Install Oracle dependencies and create Oracle users/groups
+# Install runtime dependencies
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    net-tools \
+    netbase \
     libaio1 \
     libaio-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && groupadd -g 1000 openedge \
+  && useradd -m -r -u 1000 -g openedge openedge \
   && groupadd -g 54321 oinstall \
   && groupadd -g 54322 dba \
   && groupadd -g 54323 oper \
   && useradd -g oinstall oracle
 
+# Set environment variables
+ENV JAVA_HOME=/opt/java/openjdk
+ENV DLC=/usr/dlc
+ENV WRKDIR=/usr/wrk
+ENV TERM=xterm
+ENV PATH="${DLC}:${DLC}/bin:${JAVA_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH=/opt/oracle/client/lib
+ENV ORACLE_HOME=/opt/oracle/client
+
+# Copy Java from install stage
+COPY --from=install $JAVA_HOME $JAVA_HOME
+
+# Copy OpenEdge from install stage
+COPY --from=install --chown=openedge:openedge $DLC $DLC
+COPY --from=install --chown=openedge:openedge $WRKDIR $WRKDIR
+COPY --from=install /etc/openedge.d /etc/openedge.d
+COPY --from=install /etc/openedge /etc/openedge
+COPY --from=install /etc/progress /etc/progress
+
 # Copy Oracle client from oracle stage
 COPY --from=oracle --chown=oracle:oinstall /opt/oracle /opt/oracle
 COPY --from=oracle --chown=oracle:oinstall /opt/oraInventory /opt/oraInventory
 
-# Set Oracle permissions
-RUN chmod -R 775 /opt
+# Set permissions
+WORKDIR /usr/dlc/bin
+RUN chown root _* && \
+    chmod 4755 _* && \
+    chown -R openedge:openedge $DLC/servers/pasoe && \ 
+    chmod 775 $DLC && \
+    chmod 777 $WRKDIR && \
+    touch /usr/dlc/progress.cfg  && \
+    chown openedge:openedge /usr/dlc/progress.cfg && \
+    chmod -R 775 /opt && \
+    ldconfig /opt/oracle/client/lib && \
+    echo 'tcp    6 TCP' >> /etc/protocols
 
 # Optional: Copy tnsnames.ora if you have one
 # COPY pas_orads/tnsnames.ora /opt/oracle/client/network/admin/tnsnames.ora
 
+# Note: No PASOE instance is created here - Pro2 installer will handle that
+# Remove progress.cfg after setup
 USER openedge
+RUN rm /usr/dlc/progress.cfg
 
-# Inherit CMD from pas_base
+VOLUME /usr/dlc/progress.cfg
+
+WORKDIR /usr/dlc
+
+USER root

--- a/pas_orads/pro2/Dockerfile
+++ b/pas_orads/pro2/Dockerfile
@@ -1,0 +1,42 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+LABEL maintainer="Ruben Dröge <rdroge@progress.com>"
+
+USER root
+
+COPY ./binaries/Pro2-6.5.2.bin ./response.properties /install/pro2/
+
+WORKDIR /install/pro2
+
+ENV JAVA_TOOL_OPTIONS='-Djdk.util.zip.disableZip64ExtraFieldValidation=true'
+
+# Create progress.cfg file to avoid Pro2 installer ESAM error 
+RUN touch /usr/dlc/progress.cfg && \
+    chmod +x Pro2-6.5.2.bin && \
+    ./Pro2-6.5.2.bin -i Silent -f response.properties && \
+    rm -rf Pro2-6.5.2.bin
+
+# Pro2 installer creates the PASOE instance, so we don't need to do it manually
+WORKDIR /home/openedge/install/pro2/bprepl/Scripts
+
+# Copy Oracle TNS configuration (LD_LIBRARY_PATH and ORACLE_HOME already set in base image)
+COPY tnsnames.ora /opt/oracle/client/network/admin/tnsnames.ora
+
+# Copy Pro2 configuration files
+COPY replProc.pf sports2020.pf ./ 
+COPY schemaholder/* /home/openedge/install/pro2/db/
+COPY start.sh /install/pro2/start.sh 
+
+# Set permissions and cleanup
+RUN chmod +x /install/pro2/start.sh && \
+    chown -R openedge:openedge /home/openedge/ && \
+    rm /usr/dlc/progress.cfg
+
+VOLUME /usr/dlc/progress.cfg
+
+EXPOSE 9991 9992
+
+USER openedge
+
+CMD ["/install/pro2/start.sh"]

--- a/sports2020-db/Dockerfile
+++ b/sports2020-db/Dockerfile
@@ -10,4 +10,5 @@ VOLUME /app/schema
 
 WORKDIR /app/db
 
+
 CMD [ "bash", "-c", "/app/scripts/startdb.sh" ]

--- a/tools/Generate-ResponseIni.ps1
+++ b/tools/Generate-ResponseIni.ps1
@@ -5,7 +5,7 @@
 
 .DESCRIPTION
     This script parses a Progress Software License Addendum file and generates tailored
-    response.ini files for each required container build (compiler, db_adv, pas_dev, pas_base).
+    response.ini files for each required container build (compiler, db_adv, pas_dev, pas_base, pas_orads).
     It extracts company name, serial numbers, and control codes for each product.
     For versions 12.2.17-12.2.18 and 12.8.4-12.8.8, it also generates response_update.ini files.
 
@@ -75,6 +75,10 @@ $buildConfigs = @{
     "pas_base" = @{
         "Products" = @("Progress App Server for OE", "Progress Prod AppServer for OE")
         "Path" = Join-Path $rootDir "pas_base"
+    }
+    "pas_orads" = @{
+        "Products" = @("Progress App Server for OE", "Progress Prod AppServer for OE")
+        "Path" = Join-Path $rootDir "pas_orads"
     }
 }
 

--- a/tools/generate-response-ini.sh
+++ b/tools/generate-response-ini.sh
@@ -4,7 +4,7 @@
 # Native Linux/macOS implementation (no PowerShell required)
 #
 # This script parses a Progress Software License Addendum file and generates tailored
-# response.ini files for each required container build (compiler, db_adv, pas_dev, pas_base).
+# response.ini files for each required container build (compiler, db_adv, pas_dev, pas_base, pas_orads).
 # It extracts company name, serial numbers, and control codes for each product.
 # For versions 12.2.17-12.2.18 and 12.8.4-12.8.8, it also generates response_update.ini files.
 #
@@ -47,6 +47,9 @@ get_build_config() {
         "pas_base")
             echo "Progress App Server for OE|Progress Prod AppServer for OE"
             ;;
+        "pas_orads")
+            echo "Progress App Server for OE|Progress Prod AppServer for OE"
+            ;;
         *)
             echo ""
             ;;
@@ -55,7 +58,7 @@ get_build_config() {
 
 # Get list of all build configurations
 get_build_names() {
-    echo "compiler db_adv pas_dev pas_base"
+    echo "compiler db_adv pas_dev pas_base pas_orads"
 }
 
 # Usage function


### PR DESCRIPTION
- Added pas_orads container type to build configurations and response.ini generation tools
- Implemented multi-stage Dockerfile for pas_orads with Oracle client integration
- Added Pro2 installer support with dedicated Dockerfile and configuration files
- Enhanced CDC initialization to explicitly enable CDC before table-level setup
- Updated GitHub Actions workflow to build DB_ADV container
- Improved CDC logging with consistent