### PR TITLE
refactor: simplify CDC table lookup by removing redundant FIND statement

### DIFF
--- a/db_adv/scripts/init-cdc.sh
+++ b/db_adv/scripts/init-cdc.sh
@@ -43,13 +43,10 @@ MESSAGE "CDC Level:" iLevel.
 oService = NEW DataAdminService(cDbName).
 
 /* Get the table */
-FIND FIRST oTable WHERE oTable:Name = cTableName NO-ERROR.
-IF NOT AVAILABLE oTable THEN DO:
-    oTable = oService:GetTable(cTableName) NO-ERROR.
-    IF NOT VALID-OBJECT(oTable) THEN DO:
-        MESSAGE "ERROR: Table" cTableName "not found in database" cDbName.
-        RETURN ERROR.
-    END.
+oTable = oService:GetTable(cTableName) NO-ERROR.
+IF NOT VALID-OBJECT(oTable) THEN DO:
+    MESSAGE "ERROR: Table" cTableName "not found in database" cDbName.
+    RETURN ERROR.
 END.
 
 MESSAGE "Table found:" oTable:Name.


### PR DESCRIPTION
- Removed unnecessary FIND FIRST statement before GetTable() call
- Streamlined table retrieval to use only DataAdminService:GetTable() method
- Maintained error handling for table not found scenario